### PR TITLE
Add documentation quickstart and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,12 @@
+name: Bug report
+description: Problem melden
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: Was ist passiert?
+      description: Schritte, erwartetes Ergebnis, tatsächliches Ergebnis
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,12 @@
+name: Feature request
+description: Vorschlag einreichen
+title: "[feat] "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: idea
+    attributes:
+      label: Idee
+      description: Was soll verbessert/neu gebaut werden?
+    validations:
+      required: true

--- a/.wgx/profile.yml
+++ b/.wgx/profile.yml
@@ -1,0 +1,8 @@
+name: semantAH
+version: 0.1.0
+env_priority: [devcontainer, devbox, mise, direnv, termux]
+recipes:
+  - name: index
+    cmd: "make all"
+  - name: serve
+    cmd: "cargo run -p indexd"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# CONTRIBUTING
+
+## Dev-Setup
+1. Rust ≥ 1.75, Python ≥ 3.10
+2. `make venv` (oder `uv sync`)
+3. `make all`, `cargo run -p indexd`
+
+## Konventionen
+- Rust: `cargo fmt`, `cargo clippy`
+- Python: `ruff check`, `pytest`
+- Commits: klar und klein; PRs mit reproduzierbaren Schritten
+
+## Tests
+- `just`/`make` Targets folgen noch in der Roadmap

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: uv-sync sync index graph related all clean py-freeze
+.PHONY: uv-sync venv sync index graph related all demo clean py-freeze
 
 UV := $(shell command -v uv 2>/dev/null)
 ifeq ($(UV),)
@@ -7,6 +7,8 @@ endif
 
 uv-sync:
 	uv sync
+
+venv: uv-sync
 
 sync: uv-sync
 
@@ -20,6 +22,12 @@ related:
 	uv run scripts/update_related.py
 
 all: uv-sync index graph related
+
+.PHONY: demo
+demo:
+	@echo ">> Demo-Lauf mit examples/semantah.example.yml"
+	@test -f semantah.yml || cp examples/semantah.example.yml semantah.yml
+	$(MAKE) all
 
 clean:
 	rm -f .gewebe/embeddings.parquet

--- a/README.md
+++ b/README.md
@@ -44,22 +44,35 @@ SemantAH ist eine lokal laufende Wissensgraph- und Semantik-Pipeline für Obsidi
 
 ## Quickstart
 
-1. Installiere Rust (>=1.75) und Python (>=3.10).
-2. Richte ein virtuelles Python-ENV mit `make venv` ein.
-3. Erzeuge die Artefakte in `.gewebe/` (Stub) mit `make all`.
-4. Starte den Rust-Dienst zum Testen: `cargo run -p indexd`.
+Für ein ausführliches Step-by-Step siehe **docs/quickstart.md**. Kurzform:
+
+1. **Rust & Python bereitstellen**
+   - Rust ≥ 1.75 (rustup), Python ≥ 3.10
+   - Optional: `uv` für schnelles Python-Lock/Env
+2. **Python-Env & Tools**
+   - `make venv` (oder `uv sync`)
+3. **Beispielkonfiguration**
+   - `cp examples/semantah.example.yml semantah.yml` → Pfade anpassen
+4. **Pipeline laufen lassen**
+   - `make all` (erstellt `.gewebe/`-Artefakte)
+   - `make demo` (Mini-Demo auf Basis der Example-Konfig)
+5. **Service testen**
+   - `cargo run -p indexd`
 
 ## Export
+
 - Contracts: `contracts/semantics/*.schema.json`
 - Daten-Dumps (optional): `.gewebe/out/{nodes.jsonl,edges.jsonl,reports.json}` (JSONL pro Zeile).
 
 ## Status
 
-- [x] Workspace scaffolded
-- [ ] Embeddings-Berechnung implementiert
-- [ ] Vektorindex & Persistenz
-- [ ] Obsidian-Plugin/Adapter
-- [ ] Tests & Benchmarks
+Aktuell implementiert/geplant (beweglich):
+
+- Workspace scaffolded ✅
+- Embeddings-Berechnung (Python, Provider-wahl) ✅
+- Vektorindex & Persistenz (Rust-Dienst) 🚧
+- Obsidian-Adapter / Related-Writer 🚧
+- Tests & Benchmarks 🚧 (siehe „Roadmap“)
 
 ## Veröffentlichungs-Workflow
 
@@ -71,3 +84,37 @@ SemantAH ist eine lokal laufende Wissensgraph- und Semantik-Pipeline für Obsidi
 
 MIT – passe gerne an, falls du restriktivere Policies brauchst.
 
+---
+
+## Konfiguration
+
+Eine minimale Beispiel-Konfiguration findest du in `examples/semantah.example.yml`. Wichtige Felder:
+
+- `vault_path`: Pfad zum Obsidian-Vault
+- `out_dir`: Zielverzeichnis für Artefakte (`.gewebe/`)
+- `embedder.provider`: z. B. `ollama` (lokal) oder `openai` (remote)
+- `index.top_k`: Anzahl Rückgabekandidaten pro Suche
+- `graph.cutoffs`: Grenzwerte für Kantenbildung
+- `related.write_back`: Related-Blöcke in MD-Dateien aktualisieren (true/false)
+
+## Beispiel-Workflow
+
+```bash
+cp examples/semantah.example.yml semantah.yml
+make venv        # oder: uv sync
+make all         # embeddings → index → graph → related
+cargo run -p indexd
+```
+
+## Troubleshooting (kurz)
+- **Leere Notizen / Binärdateien** → werden übersprungen, Logs prüfen (`.gewebe/logs`)
+- **Keine Embeddings** → Provider/Key prüfen, Netz oder lokales Modell
+- **Langsame Läufe** → `index.top_k` reduzieren, Batch-Größen erhöhen, nur geänderte Dateien pro Lauf verarbeiten
+
+## FAQ
+- **Wie starte ich ohne Obsidian?** → Einfach einen Ordner mit Markdown-Dateien nutzen.
+- **Kann ich Remote-LLMs verwenden?** → Ja, `embedder.provider` auf `openai`, Key via Env-Var `OPENAI_API_KEY`.
+- **Wie baue ich nur den Graphen neu?** → `make graph` nach vorhandenem `.gewebe/embeddings.parquet`.
+
+## WGX-Integration (Stub)
+Siehe `docs/wgx-konzept.md` und `.wgx/profile.yml`. Ziel: reproduzierbare Orchestrierung (devcontainer/Devbox/mise/direnv bevorzugt).

--- a/README.md
+++ b/README.md
@@ -113,7 +113,12 @@ cargo run -p indexd
 
 ## FAQ
 - **Wie starte ich ohne Obsidian?** → Einfach einen Ordner mit Markdown-Dateien nutzen.
-- **Kann ich Remote-LLMs verwenden?** → Ja, `embedder.provider` auf `openai`, Key via Env-Var `OPENAI_API_KEY`.
+- **Kann ich Remote-LLMs verwenden?**  
+  Ja, setze `embedder.provider` auf `openai` und hinterlege deinen Key via Env-Var `OPENAI_API_KEY`.  
+  Beispiel-Konfiguration:
+  ```yaml
+  embedder:
+    provider: openai
 - **Wie baue ich nur den Graphen neu?** → `make graph` nach vorhandenem `.gewebe/embeddings.parquet`.
 
 ## WGX-Integration (Stub)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,22 @@
+# Quickstart für semantAH
+
+## Voraussetzungen
+- **Rust** ≥ 1.75 (`rustup`), **Python** ≥ 3.10
+- Optional: **uv** (schnelles Lock/Env), `make`
+
+## Setup
+```bash
+make venv        # oder: uv sync
+cp examples/semantah.example.yml semantah.yml
+```
+
+## Lauf
+```bash
+make all         # erstellt .gewebe/ Artefakte
+cargo run -p indexd
+```
+
+## Hinweise
+- Logs: `.gewebe/logs`
+- Artefakte: `.gewebe/embeddings.parquet`, `.gewebe/out/*`
+- Related-Blöcke in Markdown: nur wenn `related.write_back: true`

--- a/docs/wgx-konzept.md
+++ b/docs/wgx-konzept.md
@@ -1,0 +1,9 @@
+# WGX-Konzept (Stub)
+
+Dies ist der projektspezifische Anker zur WGX-Meta-Ebene (Master-Dok liegt zentral).
+Ziele:
+- Dünner Meta-Layer über Repos (wgx up|list|run|doctor|validate|smoke)
+- Priorität der Envs: Devcontainer → Devbox → mise/direnv → Termux
+- Jede Pipeline als „Recipe“ ausführbar; deterministische Artefakte unter `.gewebe/`
+
+Siehe `.wgx/profile.yml` für die minimalen Profileinstellungen.

--- a/examples/semantah.example.yml
+++ b/examples/semantah.example.yml
@@ -1,0 +1,12 @@
+vault_path: "/path/to/your/obsidian-vault"
+out_dir: ".gewebe"
+embedder:
+  provider: "ollama"   # oder "openai"
+  model: "nomic-embed-text"  # beispielhaft
+index:
+  top_k: 20
+graph:
+  cutoffs:
+    min_similarity: 0.35
+related:
+  write_back: false

--- a/examples/semantah.example.yml
+++ b/examples/semantah.example.yml
@@ -2,7 +2,7 @@ vault_path: "/path/to/your/obsidian-vault"
 out_dir: ".gewebe"
 embedder:
   provider: "ollama"   # oder "openai"
-  model: "nomic-embed-text"  # beispielhaft
+  model: "nomic-embed-text"  # beispielsweise
 index:
   top_k: 20
 graph:


### PR DESCRIPTION
## Summary
- expand README with configuration, workflow, troubleshooting, FAQ, and WGX sections
- add quickstart and WGX concept docs plus example configuration and contributing guide
- provide issue templates, WGX profile, and Makefile demo target for example config

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e0a72fa8fc832c92c06b5866926e44