### PR TITLE
Replace deprecated retry action in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,11 +35,20 @@ jobs:
       - name: Install cargo-audit
         run: cargo install cargo-audit --force
       - name: Security audit
-        uses: actions/retry@v3
-        with:
-          timeout_minutes: 2
-          max_attempts: 4
-          command: cargo audit
+        run: |
+          for attempt in 1 2 3 4; do
+            if cargo audit; then
+              break
+            fi
+
+            if [ "$attempt" -eq 4 ]; then
+              echo "cargo audit failed after $attempt attempts" >&2
+              exit 1
+            fi
+
+            echo "cargo audit failed on attempt $attempt; retrying in 30 seconds..."
+            sleep 30
+          done
 
   python-pipeline:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- replace the deprecated actions/retry step in the security audit job
- add a shell-based retry loop for cargo audit to maintain retry behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e26db2f610832cb17d41b4ffb79eaf