### PR TITLE
Fix missing toolchain input in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:
+          toolchain: stable
           components: clippy,rustfmt
       - name: Rust cache
         uses: swatinem/rust-cache@v2


### PR DESCRIPTION
## Summary
- add the required `toolchain` input to the Rust setup step in the CI workflow

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e272cdca70832c80bc1ec263fca08d