### PR TITLE
Specify packages for setuptools build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,3 +13,11 @@ dependencies = [
     "networkx>=3.0,<4.0",
     "rich>=13.0,<14.0",
 ]
+
+[tool.setuptools]
+packages = [
+    "codex",
+    "crates",
+    "systemd",
+    "contracts",
+]


### PR DESCRIPTION
## Summary
- add an explicit list of packages to the setuptools configuration so the build backend handles the multiple top-level modules

## Testing
- python -m build *(fails: `ModuleNotFoundError: No module named 'build'` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e279420d0c832ca9855cb4b811b418