### PR TITLE
Fix newline handling in build_graph stub

### DIFF
--- a/scripts/build_graph.py
+++ b/scripts/build_graph.py
@@ -11,10 +11,8 @@ EDGES = GEWEBE / "edges.jsonl"
 
 def main() -> None:
     GEWEBE.mkdir(exist_ok=True)
-    NODES.write_text("{}
-".format(json.dumps({"id": "stub:node"})))
-    EDGES.write_text("{}
-".format(json.dumps({"s": "stub:node", "p": "related", "o": "stub:other", "w": 0.0})))
+    NODES.write_text("{}\n".format(json.dumps({"id": "stub:node"})))
+    EDGES.write_text("{}\n".format(json.dumps({"s": "stub:node", "p": "related", "o": "stub:other", "w": 0.0})))
     print("[stub] build_graph → wrote", NODES, "and", EDGES)
 
 

--- a/scripts/build_graph.py
+++ b/scripts/build_graph.py
@@ -11,8 +11,8 @@ EDGES = GEWEBE / "edges.jsonl"
 
 def main() -> None:
     GEWEBE.mkdir(exist_ok=True)
-    NODES.write_text("{}\n".format(json.dumps({"id": "stub:node"})))
-    EDGES.write_text("{}\n".format(json.dumps({"s": "stub:node", "p": "related", "o": "stub:other", "w": 0.0})))
+    NODES.write_text(f"{json.dumps({'id': 'stub:node'})}\n")
+    EDGES.write_text(f"{json.dumps({'s': 'stub:node', 'p': 'related', 'o': 'stub:other', 'w': 0.0})}\n")
     print("[stub] build_graph → wrote", NODES, "and", EDGES)
 
 


### PR DESCRIPTION
## Summary
- ensure build_graph stub writes newline-terminated JSONL entries for nodes and edges

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e27d1be110832c9a27f6a856737745