### PR TITLE
Fix security audit retry action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           tool: cargo-audit
       - name: Security audit
-        uses: nick-fields/retry@v3
+        uses: nick-fields/retry@7152eba30c6575329ac0576536151aea5a72ede3
         with:
           timeout_minutes: 10
           max_attempts: 4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           tool: cargo-audit
       - name: Security audit
-        uses: ashley-taylor/RetryStep@b7e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2
+        uses: nick-fields/retry@v3
         with:
           timeout_minutes: 10
           max_attempts: 4


### PR DESCRIPTION
## Summary
- replace the unresolvable ashley-taylor/RetryStep action with nick-fields/retry for the security audit step
- keep the existing retry configuration so cargo audit still retries on failure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e27fe9984c832c9ee540975c45be21