### PR TITLE
Replace deprecated retry action in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
         with:
           tool: cargo-audit
       - name: Security audit
-        uses: ashley-taylor/RetryStep@b7e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2e2
+        uses: nick-invision/retry@v2
         with:
           timeout_minutes: 10
           max_attempts: 4


### PR DESCRIPTION
## Summary
- replace the deprecated ashley-taylor/RetryStep action in the security audit job
- use the maintained nick-invision/retry action with equivalent retry configuration

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e27f9d0b38832c9f52107c8c7c00b7